### PR TITLE
Automatically respond to 2FA prompt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,5 +79,10 @@ For info on the Jupyter-O2 command-line options, use ``jupyter-o2 --help``.
 
 Two-factor authentication
 -------------------------
-If you see a two-factor authentication prompt when SSH'ing into O2, you will need to tell Jupyter-O2
-to request Duo pushes using the arguments ``--2fa --2fa-code 1``.
+Jupyter-O2 detects the Duo two-factor authentication prompt and
+requests a Duo push by default (code 1).
+To send a pre-generated code, use the argument ``--2fa-code <code>``,
+replacing ``<code>`` with your code.
+
+*Experimental: use* ``--2fa-code interact`` *to interactively respond to the Duo prompt.
+This allows you to request a phone or text push and enter the code you receive.*

--- a/src/jupyter_o2/config_manager.py
+++ b/src/jupyter_o2/config_manager.py
@@ -27,7 +27,7 @@ JO2_DEFAULTS = {
     "PORT_RETRIES": 10,
     "FORCE_GETPASS": False,
     "USE_TWO_FACTOR_AUTHENTICATION": False,
-    "TWO_FACTOR_AUTHENTICATION_CODE": [""],
+    "TWO_FACTOR_AUTHENTICATION_CODE": "1",
     "USE_INTERNAL_INTERACTIVE_SESSION": True,
     "INTERACTIVE_CALL_FORMAT": (
         "srun -t {time} --mem {mem} -c {cores} --pty -p {partition} "

--- a/src/jupyter_o2/jupyter-o2.cfg
+++ b/src/jupyter_o2/jupyter-o2.cfg
@@ -38,9 +38,10 @@ INIT_JUPYTER_COMMANDS =
 ;USE_TWO_FACTOR_AUTHENTICATION = False
 # Set to True to search for a two factor authentication prompt during SSH login
 
-;TWO_FACTOR_AUTHENTICATION_CODE =
+;TWO_FACTOR_AUTHENTICATION_CODE = 1
 # For Duo, set to 1 to automatically send a Duo push during SSH login
-# If multiple codes, split over multiple lines
+# Set to interact to bring up an interactive Duo prompt (experimental)
+# For multiple codes, split over multiple lines (similar to INIT_JUPYTER_COMMANDS)
 
 ;USE_INTERNAL_INTERACTIVE_SESSION = True
 # Set to True to use an internal interactive session to run Jupyter.

--- a/src/jupyter_o2/utils.py
+++ b/src/jupyter_o2/utils.py
@@ -5,10 +5,7 @@ import subprocess
 import shlex
 import ast
 
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
+from shlex import quote
 import socket
 
 
@@ -65,25 +62,6 @@ def check_dns(hostname, dns_groups=None):
     elif dns_err_code == 2:
         print(f"No IP found for {hostname}", file=sys.stderr)
     return dns_err_code, hostname
-
-
-def check_nameserver_overlap(dns_groups=None):
-    """
-    Check if the current nameservers overlap with the HMS nameservers.
-
-    :return: True if they overlap, False if not, None if error
-    """
-    try:
-        from dns.resolver import Resolver
-    except ImportError:
-        return None
-    from .config_manager import DNS_SERVER_GROUPS
-
-    if dns_groups is None:
-        dns_groups = DNS_SERVER_GROUPS[0]
-    current_nameservers = Resolver().nameservers
-
-    return bool(set(dns_groups) & set(current_nameservers))
 
 
 def check_port_occupied(port, address="127.0.0.1"):


### PR DESCRIPTION
Remote users will not have to specify `--2fa --2fa-code 1` for Jupyter-O2 to detect and respond to two-factor authentication prompts.

The `--2fa` argument and `use_2fa` variable are now unused and remain only for backwards compatibility.
Also fixes the interactive 2FA prompt, which can be accessed using `--2fa-code interact`.