### PR TITLE
Updates for 1.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         if: "contains(env.USING_COVERAGE, matrix.python-version)"
       - name: "Upload coverage to Codecov"
         if: "contains(env.USING_COVERAGE, matrix.python-version)"
-        uses: "codecov/codecov-action@v1"
+        uses: "codecov/codecov-action@v2"
         with:
           fail_ci_if_error: true
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog for Jupyter-O2
 ========================
 
+1.1.1 - 2021-11-24
+------------------
+
+Added
+^^^^^
+- Fix segmentation fault on ``import Quartz``
+- Fix ``try_quit_xquartz()`` in recent versions of macOS (Use the config option ``KEEP_XQUARTZ`` if quitting XQuartz is not desired.)
+- Remove check for root prompt at ``login()``
+
 1.1.0 - 2021-10-25
 ------------------
 

--- a/src/jupyter_o2/__init__.py
+++ b/src/jupyter_o2/__init__.py
@@ -29,7 +29,7 @@ from .config_manager import (
 )
 
 __author__ = "Aaron Kollasch"
-__date__ = "2021-10-25"
+__date__ = "2021-11-24"
 __copyright__ = "Copyright 2017-2021, Aaron Kollasch"
 __email__ = "aaron@kollasch.dev"
 __status__ = "Production"

--- a/src/jupyter_o2/config_manager.py
+++ b/src/jupyter_o2/config_manager.py
@@ -26,6 +26,7 @@ JO2_DEFAULTS = {
     "RUN_JUPYTER_CALL_FORMAT": "jupyter {subcommand} --port={port} --no-browser",
     "PORT_RETRIES": 10,
     "FORCE_GETPASS": False,
+    "KEEP_XQUARTZ": False,
     "USE_TWO_FACTOR_AUTHENTICATION": False,
     "TWO_FACTOR_AUTHENTICATION_CODE": "1",
     "USE_INTERNAL_INTERACTIVE_SESSION": True,
@@ -118,9 +119,9 @@ def get_base_arg_parser():
                         help="Code(s) to use with 2FA (1 for auto-push)")
     parser.add_argument("-k", "--keepalive", default=False, action='store_true',
                         help="keep interactive session alive after exiting Jupyter")
-    parser.add_argument("--kq", "--keepxquartz", dest="keepxquartz", default=False,
-                        action='store_true',
-                        help="do not quit XQuartz")
+    parser.add_argument("--kq", "--keepxquartz", dest="keepxquartz",
+                        default=JO2_DEFAULTS.get("KEEP_XQUARTZ"),
+                        action='store_true', help="do not quit XQuartz")
     parser.add_argument("--force-getpass", dest="forcegetpass", action='store_true',
                         default=JO2_DEFAULTS.get("FORCE_GETPASS"),
                         help="use getpass instead of pinentry for password entry")

--- a/src/jupyter_o2/jupyter-o2.cfg
+++ b/src/jupyter_o2/jupyter-o2.cfg
@@ -31,6 +31,9 @@ INIT_JUPYTER_COMMANDS =
 ;FORCE_GETPASS = False
 # Force the use of getpass instead of pinentry if the pinentry is available
 
+;KEEP_XQUARTZ = False
+# Do not quit XQuartz after starting Jupyter-O2
+
 
 [Remote Environment Settings]
 # These settings can be configured to adapt Jupyter-O2 to an environment other than O2.

--- a/src/jupyter_o2/jupyter_o2.py
+++ b/src/jupyter_o2/jupyter_o2.py
@@ -62,7 +62,7 @@ class CustomSSH(pxssh.pxssh):
         new_args = dict(
             sync_original_prompt=False,
             auto_prompt_reset=False,
-            original_prompt=f"[#$]|{self.duo_pattern}",
+            original_prompt=f"[$]|{self.duo_pattern}",
         )
         if kwargs:
             kwargs.update(new_args)
@@ -95,11 +95,11 @@ class CustomSSH(pxssh.pxssh):
                 self._buffer = self.buffer_type()
                 if code is not None:
                     self.sendline(code)
-                    i = self.expect(["[#$]", self.duo_pattern])
+                    i = self.expect(["$", self.duo_pattern])
                     logger.debug(f"Found prompt #{i}")
                     if i == 1:  # search for prompt one more time
                         self.sendline()
-                        i = self.expect(["[#$]", self.duo_pattern])
+                        i = self.expect(["$", self.duo_pattern])
                         logger.debug(f"Found prompt #{i}")
                     if i == 1:
                         self.close()


### PR DESCRIPTION
- Fix segmentation fault on import Quartz
- Fix try_quit_xquartz() in recent versions of macOS (Use the config option `KEEP_XQUARTZ` if quitting XQuartz is not desired.)
- Remove check for root prompt at login()